### PR TITLE
improvement: exclude star from state_machine_all_states/1 to avoid inclusion in add_attribute builder

### DIFF
--- a/lib/transformers/fill_in_event_defaults.ex
+++ b/lib/transformers/fill_in_event_defaults.ex
@@ -17,6 +17,7 @@ defmodule AshStateMachine.Transformers.FillInTransitionDefaults do
       end)
       |> Enum.concat(List.wrap(initial_states))
       |> Enum.uniq()
+      |> Enum.reject(&(&1 == :*))
 
     dsl_state =
       Transformer.set_option(

--- a/test/ash_state_machine_test.exs
+++ b/test/ash_state_machine_test.exs
@@ -88,6 +88,7 @@ defmodule AshStateMachineTest do
       transitions do
         transition(:begin, from: :pending, to: :executing)
         transition(:complete, from: :executing, to: :complete)
+        transition(:*, from: :*, to: :pending)
       end
     end
 
@@ -128,7 +129,7 @@ defmodule AshStateMachineTest do
   end
 
   describe "transformers" do
-    test "infers all states" do
+    test "infers all states, excluding star (:*)" do
       assert Enum.sort(AshStateMachine.Info.state_machine_all_states(ThreeStates)) ==
                Enum.sort([:executing, :pending, :complete])
     end


### PR DESCRIPTION
Star was being included as part of the add_attribute builder causing some compilation issues with absinthe

```
== Compilation error in file lib/coinbits/resources/schema.ex ==
** (Absinthe.Schema.Error) Compilation failed:
---------------------------------------

Enum value name "*" has invalid characters.

Name does not match possible ~r/^[_A-Za-z][_0-9A-Za-z]*$/ regex.

> Names in GraphQL are limited to this ASCII subset of possible characters to
> support interoperation with as many other systems as possible.
```

### Contributor checklist

- [X] Bug fixes include regression tests
- [X] Features include unit/acceptance tests
