### PR TITLE
feat: Add `next_state` builtin change.

### DIFF
--- a/lib/builtin_changes/builtin_changes.ex
+++ b/lib/builtin_changes/builtin_changes.ex
@@ -9,4 +9,9 @@ defmodule AshStateMachine.BuiltinChanges do
   def transition_state(target) do
     {AshStateMachine.BuiltinChanges.TransitionState, target: target}
   end
+
+  @doc """
+  Try and transition to the next state.
+  """
+  def next_state, do: AshStateMachine.BuiltinChanges.NextState
 end

--- a/lib/builtin_changes/next_state.ex
+++ b/lib/builtin_changes/next_state.ex
@@ -1,0 +1,39 @@
+defmodule AshStateMachine.BuiltinChanges.NextState do
+  @moduledoc """
+  Given the action and the current state, attempt to find the next state to
+  transition into.
+  """
+  use Ash.Resource.Change
+
+  def change(changeset, _opts, _) do
+    attribute = AshStateMachine.Info.state_machine_state_attribute!(changeset.resource)
+
+    current_state = Map.get(changeset.data, attribute)
+
+    changeset.resource
+    |> AshStateMachine.Info.state_machine_transitions(changeset.action.name)
+    |> Enum.filter(fn
+      %{from: from} when is_list(from) -> current_state in from
+      %{from: from} -> current_state == from
+    end)
+    |> Enum.flat_map(fn
+      %{to: to} when is_list(to) -> to
+      %{to: to} -> [to]
+    end)
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 == :*))
+    |> case do
+      [to] ->
+        AshStateMachine.transition_state(changeset, to)
+
+      [] ->
+        Ash.Changeset.add_error(changeset, "Cannot determine next state: no next state available")
+
+      _ ->
+        Ash.Changeset.add_error(
+          changeset,
+          "Cannot determine next state: multiple next states available"
+        )
+    end
+  end
+end

--- a/lib/info.ex
+++ b/lib/info.ex
@@ -2,7 +2,7 @@ defmodule AshStateMachine.Info do
   @moduledoc "Introspection helpers for `AshStateMachine`"
   use Spark.InfoGenerator, extension: AshStateMachine, sections: [:state_machine]
 
-  @spec state_machine_transitions(Ash.Resource.record() | map(), name :: atom) ::
+  @spec state_machine_transitions(Ash.Resource.t() | map(), name :: atom) ::
           list(AshStateMachine.Transition.t())
   def state_machine_transitions(resource_or_dsl, name) do
     resource_or_dsl
@@ -10,7 +10,7 @@ defmodule AshStateMachine.Info do
     |> Enum.filter(&(&1.action == :* || &1.action == name))
   end
 
-  @spec state_machine_all_states(Ash.Resource.record() | map()) :: list(atom)
+  @spec state_machine_all_states(Ash.Resource.t() | map()) :: list(atom)
   def state_machine_all_states(resource_or_dsl) do
     Spark.Dsl.Extension.get_persisted(resource_or_dsl, :all_state_machine_states, [])
   end


### PR DESCRIPTION
When there is only a single possible next state that can be transitioned into, we can automatically transition into that state.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [X] Features include unit/acceptance tests
