### PR TITLE
fix: Allow any state as a `from` state in a transition

### DIFF
--- a/lib/ash_state_machine.ex
+++ b/lib/ash_state_machine.ex
@@ -158,11 +158,12 @@ defmodule AshStateMachine do
     Ash.Changeset.add_error(other, "Can't transition states on destroy actions")
   end
 
-  defp valid_transition?(%{from: from}, _) when from == :* or from == [:*] do
-    true
+  defp valid_transition?(transition, {from, to}) do
+    valid_transition_endpoint?(List.wrap(transition.from), from) &&
+      valid_transition_endpoint?(List.wrap(transition.to), to)
   end
 
-  defp valid_transition?(transition, {from, to}) do
-    from in List.wrap(transition.from) and to in List.wrap(transition.to)
+  def valid_transition_endpoint?(endpoint_list, value) do
+    endpoint_list == [:*] || value in endpoint_list
   end
 end

--- a/lib/ash_state_machine.ex
+++ b/lib/ash_state_machine.ex
@@ -122,9 +122,7 @@ defmodule AshStateMachine do
     attribute = AshStateMachine.Info.state_machine_state_attribute!(changeset.resource)
     old_state = Map.get(changeset.data, attribute)
 
-    case Enum.find(transitions, fn transition ->
-           old_state in List.wrap(transition.from) and target in List.wrap(transition.to)
-         end) do
+    case Enum.find(transitions, &valid_transition?(&1, {old_state, target})) do
       nil ->
         Ash.Changeset.add_error(
           changeset,
@@ -158,5 +156,13 @@ defmodule AshStateMachine do
 
   def transition_state(other, _target) do
     Ash.Changeset.add_error(other, "Can't transition states on destroy actions")
+  end
+
+  defp valid_transition?(%{from: from}, _) when from == :* or from == [:*] do
+    true
+  end
+
+  defp valid_transition?(transition, {from, to}) do
+    from in List.wrap(transition.from) and to in List.wrap(transition.to)
   end
 end


### PR DESCRIPTION
According to the docs, this should have worked already, but didn't seem to

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
