### PR TITLE
Allow create upsert actions in state transitions

### DIFF
--- a/lib/ash_state_machine.ex
+++ b/lib/ash_state_machine.ex
@@ -165,17 +165,6 @@ defmodule AshStateMachine do
     Ash.Changeset.add_error(other, "Can't transition states on destroy actions")
   end
 
-  defp invalid_initial_state(changeset, target) do
-    changeset
-    |> Ash.Changeset.set_context(%{state_machine: %{attempted_change: target}})
-    |> Ash.Changeset.add_error(
-      AshStateMachine.Errors.InvalidInitialState.exception(
-        target: target,
-        action: changeset.action.name
-      )
-    )
-  end
-
   defp find_and_perform_transition(changeset, old_state, attribute, target) do
     changeset.resource
     |> AshStateMachine.Info.state_machine_transitions(changeset.action.name)
@@ -217,6 +206,17 @@ defmodule AshStateMachine do
     |> Ash.Changeset.add_error(
       AshStateMachine.Errors.NoMatchingTransition.exception(
         old_state: old_state,
+        target: target,
+        action: changeset.action.name
+      )
+    )
+  end
+
+  defp invalid_initial_state(changeset, target) do
+    changeset
+    |> Ash.Changeset.set_context(%{state_machine: %{attempted_change: target}})
+    |> Ash.Changeset.add_error(
+      AshStateMachine.Errors.InvalidInitialState.exception(
         target: target,
         action: changeset.action.name
       )

--- a/lib/verifiers/verify_transition_actions.ex
+++ b/lib/verifiers/verify_transition_actions.ex
@@ -12,16 +12,39 @@ defmodule AshStateMachine.Verifiers.VerifyTransitionActions do
     |> Enum.each(fn transition ->
       action = Ash.Resource.Info.action(dsl_state, transition.action)
 
-      unless action && action.type == :update do
-        raise Spark.Error.DslError,
-          module: Spark.Dsl.Verifier.get_persisted(dsl_state, :module),
-          path: [:state_machine, :transitions, :transition, transition.action],
-          message: """
-          Transition configured with action `:#{transition.action}` but no such update action is defined.
-          """
+      case validate(action) do
+        :ok ->
+          :ok
+
+        {:error, err} ->
+          raise Spark.Error.DslError,
+            module: Spark.Dsl.Verifier.get_persisted(dsl_state, :module),
+            path: [:state_machine, :transitions, :transition, transition.action],
+            message: """
+            #{error_message(err, transition.action)}
+            """
       end
     end)
 
     :ok
+  end
+
+  defp validate(action) do
+    case action do
+      %{type: :update} -> :ok
+      %{type: :create, upsert?: true} -> :ok
+      %{type: :create, upsert?: false} -> {:error, :create_must_upsert}
+      nil -> {:error, :no_such_action}
+    end
+  end
+
+  defp error_message(err, action) do
+    case err do
+      :no_such_action ->
+        "Transition configured with action `:#{action}` but no such action is defined. Actions must be of type update or create with `upsert?: true`"
+
+      :create_must_upsert ->
+        "Transition configured with non-upsert create action `:#{action}`. Create actions must be configured with `upsert? true` to allow state transitions."
+    end
   end
 end

--- a/lib/verifiers/verify_transition_actions.ex
+++ b/lib/verifiers/verify_transition_actions.ex
@@ -35,13 +35,14 @@ defmodule AshStateMachine.Verifiers.VerifyTransitionActions do
       %{type: :create, upsert?: true} -> :ok
       %{type: :create, upsert?: false} -> {:error, :create_must_upsert}
       nil -> {:error, :no_such_action}
+      _ -> {:error, :no_such_action}
     end
   end
 
   defp error_message(err, action) do
     case err do
       :no_such_action ->
-        "Transition configured with action `:#{action}` but no such action is defined. Actions must be of type update or create with `upsert?: true`"
+        "Transition configured with action `:#{action}` but no such create or update action is defined. Actions must be of type update or create with `upsert?: true`"
 
       :create_must_upsert ->
         "Transition configured with non-upsert create action `:#{action}`. Create actions must be configured with `upsert? true` to allow state transitions."

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule AshStateMachine.MixProject do
       docs: docs(),
       description: @description,
       source_url: "https://github.com/ash-project/ash_state_machine",
-      homepage_url: "https://github.com/ash-project/ash_state_machine"
+      homepage_url: "https://github.com/ash-project/ash_state_machine",
+      consolidate_protocols: Mix.env() != :test
     ]
   end
 

--- a/test/ash_state_machine_test.exs
+++ b/test/ash_state_machine_test.exs
@@ -50,6 +50,12 @@ defmodule AshStateMachineTest do
       assert Verification.reset!(%{id: state_machine.id}).state == :pending
     end
 
+    test "create upsert? actions do not allow invalid states" do
+      state_machine = Verification.create!() |> Verification.begin!()
+      assert {:error, reason} = Verification.broken_upsert(%{id: state_machine.id})
+      assert Exception.message(reason) =~ ~r/no matching transition/i
+    end
+
     test "create actions without `upsert? true` do not compile" do
       assert_raise Spark.Error.DslError, ~r/non-upsert create action/, fn ->
         defmodule CreateWithoutUpsert do

--- a/test/ash_state_machine_test.exs
+++ b/test/ash_state_machine_test.exs
@@ -74,8 +74,33 @@ defmodule AshStateMachineTest do
       end
     end
 
+    test "create action transitions without `from: :*` do not compile" do
+      assert_raise Spark.Error.DslError, ~r/must allow transitions from all states/, fn ->
+        defmodule CreateWithoutAllowingFromAll do
+          use Ash.Resource,
+            domain: nil,
+            extensions: [AshStateMachine]
+
+          state_machine do
+            initial_states [:pending, :howdy]
+
+            transitions do
+              transition :reset, from: :howdy, to: :pending
+            end
+          end
+
+          actions do
+            create :reset do
+              upsert? true
+              change transition_state(:pending)
+            end
+          end
+        end
+      end
+    end
+
     test "any action other than update or create with upsert? true does not compile" do
-           assert_raise Spark.Error.DslError, ~r/no such create or update action/, fn ->
+      assert_raise Spark.Error.DslError, ~r/no such create or update action/, fn ->
         defmodule DeleteAction do
           use Ash.Resource,
             domain: nil,

--- a/test/ash_state_machine_test.exs
+++ b/test/ash_state_machine_test.exs
@@ -73,6 +73,30 @@ defmodule AshStateMachineTest do
         end
       end
     end
+
+    test "any action other than update or create with upsert? true does not compile" do
+           assert_raise Spark.Error.DslError, ~r/no such create or update action/, fn ->
+        defmodule DeleteAction do
+          use Ash.Resource,
+            domain: nil,
+            extensions: [AshStateMachine]
+
+          state_machine do
+            initial_states [:pending]
+
+            transitions do
+              transition :delete, from: :*, to: :pending
+            end
+          end
+
+          actions do
+            destroy :delete do
+              change transition_state(:pending)
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "charts" do

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -6,5 +6,6 @@ defmodule Domain do
     resource ThreeStates
     resource Order
     resource NextStateMachine
+    resource Verification
   end
 end

--- a/test/support/verification.ex
+++ b/test/support/verification.ex
@@ -1,0 +1,40 @@
+defmodule Verification do
+  use Ash.Resource,
+    domain: Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshStateMachine]
+
+  state_machine do
+    initial_states [:pending]
+    default_initial_state :pending
+
+    transitions do
+      transition(:begin, from: :pending, to: :executing)
+      transition(:reset, from: :*, to: :pending)
+    end
+  end
+
+  actions do
+    default_accept :*
+    defaults [:read, :create]
+
+    update :begin do
+      change transition_state(:executing)
+    end
+
+    create :reset do
+      upsert? true
+      change transition_state(:pending)
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id, writable?: true
+  end
+
+  code_interface do
+    define :create
+    define :begin
+    define :reset
+  end
+end

--- a/test/support/verification.ex
+++ b/test/support/verification.ex
@@ -11,6 +11,7 @@ defmodule Verification do
     transitions do
       transition(:begin, from: :pending, to: :executing)
       transition(:reset, from: :*, to: :pending)
+      transition(:broken_upsert, from: :*, to: [:foo, :bar])
     end
   end
 
@@ -26,6 +27,11 @@ defmodule Verification do
       upsert? true
       change transition_state(:pending)
     end
+
+    create :broken_upsert do
+      upsert? true
+      change transition_state(:pending)
+    end
   end
 
   attributes do
@@ -36,5 +42,6 @@ defmodule Verification do
     define :create
     define :begin
     define :reset
+    define :broken_upsert
   end
 end

--- a/test/support/verification.ex
+++ b/test/support/verification.ex
@@ -1,4 +1,5 @@
 defmodule Verification do
+  @moduledoc false
   use Ash.Resource,
     domain: Domain,
     data_layer: Ash.DataLayer.Ets,


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [X] Features include unit/acceptance tests

Updated `AshStateMachine.Verifiers.VerifyTransitionActions` to allow `create` transition actions when `upsert? true` is set. 

Added tests and added `consolidate_protocols: Mix.env() != :test` to `AshStateMachine.MixProject.project` to avoid some unnecessary compiler warnings when testing. 
